### PR TITLE
Improve chart readability

### DIFF
--- a/agri-weather-compare/app/routes.py
+++ b/agri-weather-compare/app/routes.py
@@ -176,12 +176,12 @@ def index():
                 temp_data.append({
                     "label": str(year),
                     "data": temps,
-                    "borderWidth": 2,
+                    "borderWidth": 3,
                 })
                 rain_data.append({
                     "label": str(year),
                     "data": rains,
-                    "borderWidth": 2,
+                    "borderWidth": 3,
                 })
 
         else:  # monthly
@@ -210,7 +210,7 @@ def index():
                         {
                             "label": col.replace("_temp", ""),
                             "data": list(df[col]),
-                            "borderWidth": 2,
+                            "borderWidth": 3,
                         }
                     )
                 if "_rain" in col:
@@ -218,7 +218,7 @@ def index():
                         {
                             "label": col.replace("_rain", ""),
                             "data": list(df[col]),
-                            "borderWidth": 2,
+                            "borderWidth": 3,
                         }
                     )
 
@@ -230,8 +230,8 @@ def index():
                                error=f"処理中にエラーが発生しました: {e}", labels=[], temp_data=[], rain_data=[])
 
     colors = [
-        "#FF6384", "#36A2EB", "#FFCE56", "#4BC0C0",
-        "#9966FF", "#FF9F40", "#8AC926", "#6A4C93"
+        "#1b9e77", "#d95f02", "#7570b3", "#e7298a",
+        "#66a61e", "#e6ab02", "#a6761d", "#666666"
     ]
     return render_template("index.html", labels=labels, temp_data=temp_data, rain_data=rain_data,
                            location=location, valid_years=VALID_YEARS, selected_years=selected_years,

--- a/agri-weather-compare/app/templates/index.html
+++ b/agri-weather-compare/app/templates/index.html
@@ -66,6 +66,8 @@
             ...dataset,
             borderColor: colorList[i % colorList.length],
             backgroundColor: colorList[i % colorList.length],
+            borderWidth: 3,
+            pointRadius: 3,
             fill: false,
             tension: 0.3
         }));
@@ -73,35 +75,38 @@
         const coloredRainData = rainData.map((dataset, i) => ({
             ...dataset,
             borderColor: colorList[i % colorList.length],
-            backgroundColor: colorList[i % colorList.length]
+            backgroundColor: colorList[i % colorList.length],
+            borderWidth: 1
         }));
 
         new Chart(document.getElementById('tempChart'), {
             type: 'line',
-            data: { labels: labels, datasets: tempData },
+            data: { labels: labels, datasets: coloredTempData },
             options: {
                 plugins: {
                     title: {
                         display: true,
                         text: '{{ location }} - {{ selected_month }}月 の {{ "【日別】" if mode == "daily" else "【月別】" }} 平均気温（℃）',
-                        font: { size: 18 },
+                        font: { size: 20 },
                         padding: { top: 10, bottom: 10 }
                     },
                     legend: {
                         display: true,
                         position: 'bottom',
                         labels: {
-                            boxWidth: 12,
-                            font: { size: 12 }
+                            boxWidth: 14,
+                            font: { size: 14 }
                         }
                     }
                 },
                 scales: {
                     x: {
-                        ticks: { font: { size: 12 } }
+                        ticks: { font: { size: 14 } },
+                        grid: { color: '#e0e0e0' }
                     },
                     y: {
-                        ticks: { font: { size: 12 } }
+                        ticks: { font: { size: 14 } },
+                        grid: { color: '#e0e0e0' }
                     }
                 }
             }
@@ -120,24 +125,26 @@
                     title: {
                         display: true,
                         text: '{{ location }} - {{ selected_month }}月 の {{ "【日別】" if mode == "daily" else "【月別】" }} 降水量合計（mm）',
-                        font: { size: 18 },
+                        font: { size: 20 },
                         padding: { top: 10, bottom: 10 }
                     },
                     legend: {
                         display: true,
                         position: 'bottom',
                         labels: {
-                            boxWidth: 12,
-                            font: { size: 12 }
+                            boxWidth: 14,
+                            font: { size: 14 }
                         }
                     }
                 },
                 scales: {
                     x: {
-                        ticks: { font: { size: 12 } }
+                        ticks: { font: { size: 14 } },
+                        grid: { color: '#e0e0e0' }
                     },
                     y: {
-                        ticks: { font: { size: 12 } }
+                        ticks: { font: { size: 14 } },
+                        grid: { color: '#e0e0e0' }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- use a colorblind-friendly palette for charts
- apply thicker lines, clearer points and grid lines for better visibility
- enlarge chart title, legend and tick fonts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68944ef292b88330aaa0d4233eb51188