### PR TITLE
Integrate humidity metrics in weather comparison routes

### DIFF
--- a/agri-weather-compare/scripts/fetch_data.py
+++ b/agri-weather-compare/scripts/fetch_data.py
@@ -16,7 +16,11 @@ def fetch_weather_data(lat, lon, year, location_name):
         "longitude": lon,
         "start_date": start_date,
         "end_date": end_date,
-        "daily": ["temperature_2m_mean", "precipitation_sum"],
+        "daily": [
+            "temperature_2m_mean",
+            "precipitation_sum",
+            "relative_humidity_2m_mean",
+        ],
         "timezone": "Asia/Tokyo"
     }
 


### PR DESCRIPTION
## Summary
- add relative humidity to downloaded daily weather data
- ensure route loaders re-fetch files lacking humidity columns

## Testing
- `pip install flask pandas matplotlib requests`
- `pytest`
- `python - <<'PY'
from app.routes import app
with app.test_client() as client:
    resp = client.get('/?location=Tokyo&years=2020&mode=monthly')
    print('status', resp.status_code)
    print('content_length', len(resp.data))
PY`
- `python - <<'PY'
from app.routes import app
with app.test_client() as client:
    resp = client.get('/?location=Tokyo&years=2020&mode=daily&month=1')
    print('status', resp.status_code)
    print('content_length', len(resp.data))
PY`


------
https://chatgpt.com/codex/tasks/task_e_6894592e025c8330bf1e09f97126fb56